### PR TITLE
fix: correct shadow className typo in OnboardingScreen

### DIFF
--- a/src/components/intro/OnboardingScreen.tsx
+++ b/src/components/intro/OnboardingScreen.tsx
@@ -227,7 +227,7 @@ export const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ onComplete }
           >
             {/* Gradient border with rounded corners */}
             <div 
-              className="absolute hadow-[inset_0_0_0_2px_theme(colors.blue.500)] inset-0 bg-gradient-to-r from-cyan-400 via-purple-500 to-green-400 p-[2px] rounded-xl"
+              className="absolute shadow-[inset_0_0_0_2px_theme(colors.blue.500)] inset-0 bg-gradient-to-r from-cyan-400 via-purple-500 to-green-400 p-[2px] rounded-xl"
             >
               <div 
                 className="w-full h-full bg-gradient-to-r from-purple-600 to-blue-600 rounded-xl"


### PR DESCRIPTION
Fixed typo in line 230 where 'hadow-' was incorrectly written instead of 'shadow-' in the gradient border className.