### PR TITLE
Fix image source path in LoadingScreen component

### DIFF
--- a/src/components/intro/LoadingScreen.tsx
+++ b/src/components/intro/LoadingScreen.tsx
@@ -14,7 +14,7 @@ const CharlieUnicornLogo = () => (
     transition={{ duration: 1, ease: "backOut" }}
   >
     <img
-      src="assets/images/first_image.svg"
+      src="/assets/images/first_image.svg"
       alt="Charlie Unicorn AI"
       className="w-full h-full object-contain drop-shadow-2xl"
     />


### PR DESCRIPTION
This PR fixes an inconsistency in `src/components/intro/LoadingScreen.tsx` where one
image path was missing the leading slash (`/`), causing a relative-path resolution
instead of an absolute one.